### PR TITLE
Auto-update ssh keys

### DIFF
--- a/_setup.sh
+++ b/_setup.sh
@@ -2,7 +2,6 @@
 
 user=$1
 address=$2
-key=`cat ~/.ssh/id_rsa.pub`
 
 echo "Connecting to $address"
 conf=~/.ssh/known_hosts
@@ -18,7 +17,11 @@ else
     sudo usermod -aG sudo $user
     sudo mkdir -p /home/$user/.ssh
     sudo chown -R $user /home/$user
-    sudo sh -c 'echo $key > /home/$user/.ssh/authorized_keys'
+
+    sudo wget https://github.com/$user.keys -O /home/$user/.ssh/authorized_keys
+    echo "*/10 * * * * /usr/bin/wget https://github.com/$user.keys -O ~/.ssh/authorized_keys" >> /tmp/cronjobs
+    sudo crontab -u $user /tmp/cronjobs
+
     sudo sh -c 'echo "$user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/010_$user-nopasswd'
 EOF
 


### PR DESCRIPTION
I just lost access to my main laptop, meaning I also lost access to the cluster, as the ssh key is stored there.
This (untested) will auto-update the ssh keys using the ones on my github account every 10 minutes, so access can be granted more easily.